### PR TITLE
Minor Code and Documentation Fixes (#250, closes #243, #244, #245, #2…

### DIFF
--- a/direct/data/datasets_config.py
+++ b/direct/data/datasets_config.py
@@ -14,7 +14,7 @@ from direct.config.defaults import BaseConfig
 
 @dataclass
 class CropTransformConfig(BaseConfig):
-    crop: Optional[Tuple[int, int]] = None
+    crop: Optional[str] = None
     crop_type: Optional[str] = "uniform"
     image_center_crop: bool = False
 

--- a/direct/data/mri_transforms.py
+++ b/direct/data/mri_transforms.py
@@ -17,7 +17,7 @@ import torchvision
 from direct.algorithms.mri_algorithms import EspiritCalibration
 from direct.data import transforms as T
 from direct.exceptions import ItemNotFoundException
-from direct.types import DirectEnum, KspaceKey
+from direct.types import DirectEnum, IntegerListOrTupleString, KspaceKey
 from direct.utils import DirectModule, DirectTransform
 from direct.utils.asserts import assert_complex
 
@@ -408,7 +408,9 @@ class CropKspace(DirectTransform):
 
         backprojected_kspace = self.backward_operator(kspace, dim=(1, 2))  # shape (coil, height, width, complex=2)
 
-        if isinstance(self.crop, str):
+        if isinstance(self.crop, IntegerListOrTupleString):
+            crop_shape = IntegerListOrTupleString(self.crop)
+        elif isinstance(self.crop, str):
             assert self.crop in sample, f"Not found {self.crop} key in sample."
             crop_shape = sample[self.crop][:2]
         else:

--- a/direct/inference.py
+++ b/direct/inference.py
@@ -13,7 +13,7 @@ from direct.data.datasets import build_dataset_from_input
 from direct.data.mri_transforms import build_mri_transforms
 from direct.environment import setup_inference_environment
 from direct.types import FileOrUrl, PathOrString
-from direct.utils import chunks, remove_keys
+from direct.utils import chunks, dict_flatten, remove_keys
 from direct.utils.io import read_list
 from direct.utils.writers import write_output_to_h5
 
@@ -135,7 +135,7 @@ def build_inference_transforms(env, mask_func: Callable, dataset_cfg: DictConfig
         backward_operator=env.engine.backward_operator,
         mask_func=mask_func,
     )
-    transforms = partial_build_mri_transforms(**remove_keys(dataset_cfg.transforms, "masking"))
+    transforms = partial_build_mri_transforms(**dict_flatten(remove_keys(dataset_cfg.transforms, "masking")))
     return transforms
 
 

--- a/direct/types.py
+++ b/direct/types.py
@@ -46,3 +46,85 @@ class DirectEnum(str, Enum):
 class KspaceKey(DirectEnum):
     kspace = "kspace"
     masked_kspace = "masked_kspace"
+
+
+class IntegerListOrTupleStringMeta(type):
+    """Metaclass for the :class:`IntegerListOrTupleString` class.
+
+    Returns
+    -------
+    bool
+        True if the instance is a valid representation of IntegerListOrTupleString, False otherwise.
+    """
+
+    def __instancecheck__(cls, instance):
+        """Check if the given instance is a valid representation of an IntegerListOrTupleString.
+
+        Parameters
+        ----------
+        cls : type
+            The class being checked, i.e., IntegerListOrTupleStringMeta.
+        instance : object
+            The instance being checked.
+
+        Returns
+        -------
+        bool
+            True if the instance is a valid representation of IntegerListOrTupleString, False otherwise.
+        """
+        if isinstance(instance, str):
+            try:
+                assert (instance.startswith("[") and instance.endswith("]")) or (
+                    instance.startswith("(") and instance.endswith(")")
+                )
+                elements = instance.strip()[1:-1].split(",")
+                integers = [int(element) for element in elements]
+                return all(isinstance(num, int) for num in integers)
+            except (AssertionError, ValueError, AttributeError):
+                pass
+        return False
+
+
+class IntegerListOrTupleString(metaclass=IntegerListOrTupleStringMeta):
+    """IntegerListOrTupleString class represents a list or tuple of integers based on a string representation.
+
+    Examples
+    --------
+    s1 = "[1, 2, 45, -1, 0]"
+    print(isinstance(s1, IntegerListOrTupleString))  # True
+    print(IntegerListOrTupleString(s1))  # [1, 2, 45, -1, 0]
+    print(type(IntegerListOrTupleString(s1)))  # <class 'list'>
+    print(type(IntegerListOrTupleString(s1)[0]))  # <class 'int'>
+
+    s2 = "(10, -9, 20)"
+    print(isinstance(s2, IntegerListOrTupleString))  # True
+    print(IntegerListOrTupleString(s2))  # (10, -9, 20)
+    print(type(IntegerListOrTupleString(s2)))  # <class 'tuple'>
+    print(type(IntegerListOrTupleString(s2)[0]))  # <class 'int'>
+
+    s3 = "[a, we, 2]"
+    print(isinstance(s3, IntegerListOrTupleString))  # False
+
+    s4 = "(1, 2, 3]"
+    print(isinstance(s4 IntegerListOrTupleString))  # False
+    """
+
+    def __new__(cls, string):
+        """
+        Create a new instance of IntegerListOrTupleString based on the given string representation.
+
+        Parameters
+        ----------
+        string : str
+            The string representation of the integer list or tuple.
+
+        Returns
+        -------
+        list or tuple
+            A new instance of IntegerListOrTupleString.
+        """
+        list_or_tuple = list if string.startswith("[") else tuple
+        string = string.strip()[1:-1]  # Remove outer brackets
+        elements = string.split(",")
+        integers = [int(element) for element in elements]
+        return list_or_tuple(integers)

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -4,16 +4,18 @@
 Configuration
 =============
 
-To perform experiments for training, validation or inference, a configuration file with an extension ``.yaml`` must be defined which includes all experiments parameters such as models, datasets, etc. The following is a template for the configuration file. Accepted arguments are the parameters as defined in the ``config<>.py`` file for each function/class. For instance, accepted arguments for training are the parameters as defined in ``TrainingConfig``. A list of our configuration files can be found in the `projects <../projects/>`_ folder.
+To perform experiments for training, validation or inference, a configuration file
+with an extension `.yaml` must be defined which includes all experiments parameters such as models,
+datasets, etc. The following is a template for the configuration file.
 
 .. code-block:: yaml
-  
+
   model:
   model_name: <nn_model_path>
   model_parameter_1: <nn_model_paramter_1>
   model_parameter_2: <nn_model_paramter_2>
   ...
-  
+
   additional_models:
     sensitivity_model:
       model_name: <nn_sensitivity_model_path>
@@ -31,9 +33,13 @@ To perform experiments for training, validation or inference, a configuration fi
       - <path_to_list_1_for_Dataset1>
       - <path_to_list_2_for_Dataset1>
       transforms:
-        estimate_sensitivity_maps: <true_or_false>
-        scaling_key: <scaling_key>
-        image_center_crop: <true_or_false>
+        cropping:
+            crop: <shape_or_str>
+            image_center_crop: <true_or_false>
+        sensitivity_map_estimation:
+            estimate_sensitivity_maps: <true_or_false>
+        normalization:
+            scaling_key: <stringg>
         masking:
           name: MaskingFunctionName
           accelerations: [acceleration_1, accelaration_2, ...]
@@ -109,3 +115,12 @@ To perform experiments for training, validation or inference, a configuration fi
   logging:
     tensorboard:
       num_images: <num_images>
+
+The following configuration files are accepted for each field:
+
+* physics, training, and validation configurations: ``direct/config/defaults.py``
+* transforms configurations: ``direct/data/datasets_config.py``
+* model configurations: ``direct/nn/<model_name>/config.py``
+
+A list of our configuration files can be found in
+the `projects <https://github.com/NKI-AI/direct/tree/main/projects>`_ folder.

--- a/docs/datasets.rst
+++ b/docs/datasets.rst
@@ -60,10 +60,14 @@ Follow the steps below:
             self.filenames_filter = filenames_filter
 
             self.text_description = text_description
-
+            self.ndim = # 2 or 3
+            self.volume_indices = self.set_volume_indices(...)
             ...
 
-        def self.get_dataset_len(self):
+        def set_volume_indices(self, ...):
+            ...
+
+        def get_dataset_len(self):
             ...
 
         def __len__(self):
@@ -87,11 +91,12 @@ should split three-dimensional data to slices of two-dimensional data.
 
 .. code-block:: python
 
+    ...
+
     @dataclass
     class MyDatasetConfig(BaseConfig):
         ...
         name: str = "MyNew"
-        lists: List[str] = field(default_factory=lambda: [])
         transforms: BaseConfig = TransformsConfig()
         text_description: Optional[str] = None
         ...

--- a/projects/calgary_campinas/configs/base_cirim.yaml
+++ b/projects/calgary_campinas/configs/base_cirim.yaml
@@ -6,27 +6,31 @@ physics:
     backward_operator: ifft2(centered=False)
 training:
     datasets:
-        # Two datasets, only difference is the shape, so the data can be collated for larger batches
+        # Two datasets, only difference is the shape, so the data can be collated for larger batches. R=5
         -   name: CalgaryCampinas
-            lists:
+            filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
             crop_outer_slices: true
         -   name: CalgaryCampinas
-            lists:
+            filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
         # Twice the same dataset but a different acceleration factor
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -67,9 +74,12 @@ validation:
             text_description: 5x  # Description for logging
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -98,13 +108,3 @@ additional_models:
 logging:
     tensorboard:
         num_images: 4
-inference:
-    batch_size: 8
-    dataset:
-        name: CalgaryCampinas
-        crop_outer_slices: true
-        text_description: inference
-        transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace

--- a/projects/calgary_campinas/configs/base_conjgradnet.yaml
+++ b/projects/calgary_campinas/configs/base_conjgradnet.yaml
@@ -8,26 +8,30 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
-            crop_outer_slices: false
+            crop_outer_slices: true
         -   name: CalgaryCampinas
             filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
-            crop_outer_slices: false
+            crop_outer_slices: true
     batch_size: 2  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.001
@@ -54,9 +58,12 @@ validation:
         # Twice the same dataset but a different acceleration factor
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -64,9 +71,12 @@ validation:
             text_description: 5x  # Description for logging
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -100,13 +110,3 @@ additional_models:
 logging:
     tensorboard:
         num_images: 4
-inference:
-    batch_size: 8
-    dataset:
-        name: CalgaryCampinas
-        crop_outer_slices: true
-        text_description: inference
-        transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace

--- a/projects/calgary_campinas/configs/base_jointicnet.yaml
+++ b/projects/calgary_campinas/configs/base_jointicnet.yaml
@@ -3,15 +3,17 @@ physics:
     backward_operator: ifft2(centered=False)
 training:
     datasets:
-        # Two datasets, only difference is the shape, so the data can be collated for larger batches
+        # Two datasets, only difference is the shape, so the data can be collated for larger batches. R=5
         -   name: CalgaryCampinas
             filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -54,9 +58,12 @@ validation:
         # Twice the same dataset but a different acceleration factor
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -64,9 +71,12 @@ validation:
             text_description: 5x  # Description for logging
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -88,13 +98,3 @@ model:
 logging:
     tensorboard:
         num_images: 4
-inference:
-    batch_size: 8
-    dataset:
-        name: CalgaryCampinas
-        crop_outer_slices: true
-        text_description: inference
-        transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace

--- a/projects/calgary_campinas/configs/base_kikinet.yaml
+++ b/projects/calgary_campinas/configs/base_kikinet.yaml
@@ -3,15 +3,17 @@ physics:
     backward_operator: ifft2(centered=False)
 training:
     datasets:
-        # Two datasets, only difference is the shape, so the data can be collated for larger batches
+        # Two datasets, only difference is the shape, so the data can be collated for larger batches. R=5
         -   name: CalgaryCampinas
             filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,17 +22,19 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
             crop_outer_slices: true
-    batch_size: 8  # This is the batch size per GPU!
+    batch_size: 4  # This is the batch size per GPU!
     optimizer: Adam
-    lr: 0.0002
+    lr: 0.0005
     weight_decay: 0.0
     lr_step_size: 50000
     lr_gamma: 0.2
@@ -54,9 +58,12 @@ validation:
         # Twice the same dataset but a different acceleration factor
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -64,9 +71,12 @@ validation:
             text_description: 5x  # Description for logging
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -98,13 +108,3 @@ additional_models:
 logging:
     tensorboard:
         num_images: 4
-inference:
-    batch_size: 8
-    dataset:
-        name: CalgaryCampinas
-        crop_outer_slices: true
-        text_description: inference
-        transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace

--- a/projects/calgary_campinas/configs/base_lpd.yaml
+++ b/projects/calgary_campinas/configs/base_lpd.yaml
@@ -3,15 +3,17 @@ physics:
     backward_operator: ifft2(centered=False)
 training:
     datasets:
-        # Two datasets, only difference is the shape, so the data can be collated for larger batches
+        # Two datasets, only difference is the shape, so the data can be collated for larger batches. R=5
         -   name: CalgaryCampinas
             filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,17 +22,19 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
             crop_outer_slices: true
-    batch_size: 3  # This is the batch size per GPU!
+    batch_size: 4  # This is the batch size per GPU!
     optimizer: Adam
-    lr: 0.001
+    lr: 0.0005
     weight_decay: 0.0
     lr_step_size: 50000
     lr_gamma: 0.2
@@ -54,9 +58,12 @@ validation:
         # Twice the same dataset but a different acceleration factor
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -64,9 +71,12 @@ validation:
             text_description: 5x  # Description for logging
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -95,13 +105,3 @@ additional_models:
 logging:
     tensorboard:
         num_images: 4
-inference:
-    batch_size: 8
-    dataset:
-        name: CalgaryCampinas
-        crop_outer_slices: true
-        text_description: inference
-        transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace

--- a/projects/calgary_campinas/configs/base_multidomainnet.yaml
+++ b/projects/calgary_campinas/configs/base_multidomainnet.yaml
@@ -3,15 +3,17 @@ physics:
     backward_operator: ifft2(centered=False)
 training:
     datasets:
-        # Two datasets, only difference is the shape, so the data can be collated for larger batches
+        # Two datasets, only difference is the shape, so the data can be collated for larger batches. R=5
         -   name: CalgaryCampinas
             filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,17 +22,19 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
             crop_outer_slices: true
-    batch_size: 20
+    batch_size: 4  # This is the batch size per GPU!
     optimizer: Adam
-    lr: 0.001
+    lr: 0.0005
     weight_decay: 0.0
     lr_step_size: 50000
     lr_gamma: 0.2
@@ -54,9 +58,12 @@ validation:
         # Twice the same dataset but a different acceleration factor
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -64,9 +71,12 @@ validation:
             text_description: 5x  # Description for logging
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -93,13 +103,3 @@ additional_models:
 logging:
     tensorboard:
         num_images: 4
-inference:
-    batch_size: 8
-    dataset:
-        name: CalgaryCampinas
-        crop_outer_slices: true
-        text_description: inference
-        transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace

--- a/projects/calgary_campinas/configs/base_recurrentvarnet.yaml
+++ b/projects/calgary_campinas/configs/base_recurrentvarnet.yaml
@@ -1,6 +1,5 @@
 # This model is a reproduction of the algorithm submitted in the Calgary-Campinas Multi-channel MR Reconstruction (MC-MRRec) Challenge
 # and is among the top-two solutions.
-
 physics:
     forward_operator: fft2(centered=False)
     backward_operator: ifft2(centered=False)
@@ -11,10 +10,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -23,22 +24,24 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
             crop_outer_slices: false
-    batch_size: 2  # This is the batch size per GPU!
+    batch_size: 4  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.0005
     weight_decay: 0.0
     lr_step_size: 50000
     lr_gamma: 0.2
     lr_warmup_iter: 1000
-    num_iterations: 1000000
+    num_iterations: 500000
     gradient_steps: 1
     gradient_clipping: 0.0
     gradient_debug: false
@@ -57,9 +60,12 @@ validation:
         # Twice the same dataset but a different acceleration factor
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -67,9 +73,12 @@ validation:
             text_description: 5x  # Description for logging
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -102,13 +111,3 @@ additional_models:
 logging:
     tensorboard:
         num_images: 4
-inference:
-    batch_size: 8
-    dataset:
-        name: CalgaryCampinas
-        crop_outer_slices: true
-        text_description: inference
-        transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace

--- a/projects/calgary_campinas/configs/base_rim.yaml
+++ b/projects/calgary_campinas/configs/base_rim.yaml
@@ -1,20 +1,21 @@
 # This model is a reproduction with some small changes of our winning algorithm in the Calgary-Campinas challenge
-# at MIDL2020. It has an improved sensitivity estimation and better metric logging capabilities based on DIRECT v0.2
-# features.
+# at MIDL2020.
 physics:
     forward_operator: fft2(centered=False)
     backward_operator: ifft2(centered=False)
 training:
     datasets:
-        # Two datasets, only difference is the shape, so the data can be collated for larger batches
+        # Two datasets, only difference is the shape, so the data can be collated for larger batches. R=5
         -   name: CalgaryCampinas
             filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -23,28 +24,30 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
             crop_outer_slices: true
     batch_size: 4  # This is the batch size per GPU!
     optimizer: Adam
-    lr: 0.0001
+    lr: 0.0005
     weight_decay: 0.0
     lr_step_size: 50000
     lr_gamma: 0.2
     lr_warmup_iter: 1000
-    num_iterations: 1000000
+    num_iterations: 500000
     gradient_steps: 1
     gradient_clipping: 0.0
     gradient_debug: false
     checkpointer:
         checkpoint_steps: 500
-    validation_steps: 500 # With batch size 4 and 4 GPUs this is about 7300 iterations, or ~1 epoch.
+    validation_steps: 500
     loss:
         crop: null
         losses:
@@ -57,9 +60,12 @@ validation:
         # Twice the same dataset but a different acceleration factor
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -67,9 +73,12 @@ validation:
             text_description: 5x  # Description for logging
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -102,13 +111,3 @@ additional_models:
 logging:
     tensorboard:
         num_images: 4
-inference:
-    batch_size: 8
-    dataset:
-        name: CalgaryCampinas
-        crop_outer_slices: true
-        text_description: inference
-        transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace

--- a/projects/calgary_campinas/configs/base_unet.yaml
+++ b/projects/calgary_campinas/configs/base_unet.yaml
@@ -3,15 +3,17 @@ physics:
     backward_operator: ifft2(centered=False)
 training:
     datasets:
-        # Two datasets, only difference is the shape, so the data can be collated for larger batches
+        # Two datasets, only difference is the shape, so the data can be collated for larger batches. R=5
         -   name: CalgaryCampinas
             filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,28 +22,30 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
             crop_outer_slices: true
-    batch_size: 32  # This is the batch size per GPU!
+    batch_size: 4  # This is the batch size per GPU!
     optimizer: Adam
-    lr: 0.0002
+    lr: 0.0005
     weight_decay: 0.0
     lr_step_size: 50000
     lr_gamma: 0.2
-    lr_warmup_iter: 3000
+    lr_warmup_iter: 1000
     num_iterations: 500000
     gradient_steps: 1
     gradient_clipping: 0.0
     gradient_debug: false
     checkpointer:
         checkpoint_steps: 500
-    validation_steps: 2000
+    validation_steps: 500
     loss:
         crop: null
         losses:
@@ -49,16 +53,17 @@ training:
                 multiplier: 1.0
             -   function: ssim_loss
                 multiplier: 1.0
-            -   function: l2_loss
-                multiplier: 1.0
 validation:
     datasets:
         # Twice the same dataset but a different acceleration factor
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -66,9 +71,12 @@ validation:
             text_description: 5x  # Description for logging
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -94,13 +102,3 @@ additional_models:
 logging:
     tensorboard:
         num_images: 4
-inference:
-    batch_size: 8
-    dataset:
-        name: CalgaryCampinas
-        crop_outer_slices: true
-        text_description: inference
-        transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace

--- a/projects/calgary_campinas/configs/base_varnet.yaml
+++ b/projects/calgary_campinas/configs/base_varnet.yaml
@@ -3,15 +3,17 @@ physics:
     backward_operator: ifft2(centered=False)
 training:
     datasets:
-        # Two datasets, only difference is the shape, so the data can be collated for larger batches
+        # Two datasets, only difference is the shape, so the data can be collated for larger batches. R=5
         -   name: CalgaryCampinas
             filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,21 +22,23 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
             crop_outer_slices: true
-    batch_size: 16  # This is the batch size per GPU!
+    batch_size: 4  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.0005
     weight_decay: 0.0
     lr_step_size: 50000
     lr_gamma: 0.2
-    lr_warmup_iter: 1500
+    lr_warmup_iter: 1000
     num_iterations: 500000
     gradient_steps: 1
     gradient_clipping: 0.0
@@ -45,18 +49,21 @@ training:
     loss:
         crop: null
         losses:
-            -   function: ssim_loss
-                multiplier: 1.0
             -   function: l1_loss
+                multiplier: 1.0
+            -   function: ssim_loss
                 multiplier: 1.0
 validation:
     datasets:
         # Twice the same dataset but a different acceleration factor
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -64,9 +71,12 @@ validation:
             text_description: 5x  # Description for logging
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -92,13 +102,3 @@ additional_models:
 logging:
     tensorboard:
         num_images: 4
-inference:
-    batch_size: 8
-    dataset:
-        name: CalgaryCampinas
-        crop_outer_slices: true
-        text_description: inference
-        transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace

--- a/projects/calgary_campinas/configs/base_xpdnet.yaml
+++ b/projects/calgary_campinas/configs/base_xpdnet.yaml
@@ -3,15 +3,17 @@ physics:
     backward_operator: ifft2(centered=False)
 training:
     datasets:
-        # Two datasets, only difference is the shape, so the data can be collated for larger batches
+        # Two datasets, only difference is the shape, so the data can be collated for larger batches. R=5
         -   name: CalgaryCampinas
             filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,17 +22,19 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
             crop_outer_slices: true
-    batch_size: 8  # This is the batch size per GPU!
+    batch_size: 4  # This is the batch size per GPU!
     optimizer: Adam
-    lr: 0.0002
+    lr: 0.0005
     weight_decay: 0.0
     lr_step_size: 50000
     lr_gamma: 0.2
@@ -54,9 +58,12 @@ validation:
         # Twice the same dataset but a different acceleration factor
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -64,9 +71,12 @@ validation:
             text_description: 5x  # Description for logging
         -   name: CalgaryCampinas
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -98,13 +108,3 @@ additional_models:
 logging:
     tensorboard:
         num_images: 4
-inference:
-    batch_size: 8
-    dataset:
-        name: CalgaryCampinas
-        crop_outer_slices: true
-        text_description: inference
-        transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs/ablation/base_recurrentvarnet_T11.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs/ablation/base_recurrentvarnet_T11.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs/ablation/base_recurrentvarnet_noRSI.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs/ablation/base_recurrentvarnet_noRSI.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs/ablation/base_recurrentvarnet_noSER.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs/ablation/base_recurrentvarnet_noSER.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs/ablation/base_recurrentvarnet_shared.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs/ablation/base_recurrentvarnet_shared.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs/base_recurrentvarnet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs/base_recurrentvarnet.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../lists/val/12x218x170_val.lst
                 - ../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../lists/val/12x218x170_val.lst
                 - ../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs/comparisons/base_rim.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs/comparisons/base_rim.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs/comparisons/base_unet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs/comparisons/base_unet.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs/comparisons/base_varnet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs/comparisons/base_varnet.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs/comparisons/base_xpdnet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs/comparisons/base_xpdnet.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/10x/ablation/base_recurrentvarnet_T11.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/10x/ablation/base_recurrentvarnet_T11.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -109,9 +119,12 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: CalgaryCampinas
                 accelerations: [ 10 ]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/10x/ablation/base_recurrentvarnet_noRSI.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/10x/ablation/base_recurrentvarnet_noRSI.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -105,9 +115,12 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: CalgaryCampinas
                 accelerations: [ 10 ]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/10x/ablation/base_recurrentvarnet_noSER.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/10x/ablation/base_recurrentvarnet_noSER.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -101,9 +111,12 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: CalgaryCampinas
                 accelerations: [ 10 ]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/10x/ablation/base_recurrentvarnet_shared.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/10x/ablation/base_recurrentvarnet_shared.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -110,9 +120,12 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: CalgaryCampinas
                 accelerations: [ 10 ]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/10x/base_recurrentvarnet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/10x/base_recurrentvarnet.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../lists/val/12x218x170_val.lst
                 - ../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../lists/val/12x218x170_val.lst
                 - ../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -109,9 +119,12 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: CalgaryCampinas
                 accelerations: [ 10 ]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/10x/comparisons/base_rim.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/10x/comparisons/base_rim.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -110,9 +120,12 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: CalgaryCampinas
                 accelerations: [ 10 ]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/10x/comparisons/base_unet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/10x/comparisons/base_unet.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -103,9 +113,12 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: CalgaryCampinas
                 accelerations: [ 10 ]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/10x/comparisons/base_varnet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/10x/comparisons/base_varnet.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -104,9 +114,12 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: CalgaryCampinas
                 accelerations: [ 10 ]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/10x/comparisons/base_xpdnet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/10x/comparisons/base_xpdnet.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -106,9 +116,12 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: CalgaryCampinas
                 accelerations: [ 10 ]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/5x/ablation/base_recurrentvarnet_T11.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/5x/ablation/base_recurrentvarnet_T11.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -109,9 +119,12 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: CalgaryCampinas
                 accelerations: [ 5 ]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/5x/ablation/base_recurrentvarnet_noRSI.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/5x/ablation/base_recurrentvarnet_noRSI.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -105,9 +115,12 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: CalgaryCampinas
                 accelerations: [ 5 ]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/5x/ablation/base_recurrentvarnet_noSER.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/5x/ablation/base_recurrentvarnet_noSER.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -101,9 +111,12 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: CalgaryCampinas
                 accelerations: [ 5 ]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/5x/ablation/base_recurrentvarnet_shared.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/5x/ablation/base_recurrentvarnet_shared.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -110,12 +120,14 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: CalgaryCampinas
                 accelerations: [ 5 ]
         crop_outer_slices: true
         text_description: inference_5x  # Description for logging
-

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/5x/base_recurrentvarnet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/5x/base_recurrentvarnet.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../lists/val/12x218x170_val.lst
                 - ../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../lists/val/12x218x170_val.lst
                 - ../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -109,9 +119,12 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: CalgaryCampinas
                 accelerations: [ 5 ]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/5x/comparisons/base_rim.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/5x/comparisons/base_rim.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -110,9 +120,12 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: CalgaryCampinas
                 accelerations: [ 5 ]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/5x/comparisons/base_unet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/5x/comparisons/base_unet.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -103,9 +113,12 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: CalgaryCampinas
                 accelerations: [ 5 ]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/5x/comparisons/base_varnet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/5x/comparisons/base_varnet.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -104,9 +114,12 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: CalgaryCampinas
                 accelerations: [ 5 ]

--- a/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/5x/comparisons/base_xpdnet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/calgary_campinas/configs_inference/5x/comparisons/base_xpdnet.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../../lists/val/12x218x170_val.lst
                 - ../../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: CalgaryCampinas
                     accelerations: [10]
@@ -106,9 +116,12 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: CalgaryCampinas
                 accelerations: [ 5 ]

--- a/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs/base_lpd.yaml
+++ b/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs/base_lpd.yaml
@@ -7,28 +7,30 @@ training:
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
         -   name: FastMRI
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
                     center_fractions: [0.04]
-            crop_outer_slices: false
     batch_size: 1  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.002
@@ -57,22 +59,27 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
             text_description: 4x  # Description for logging
         -   name: FastMRI
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]

--- a/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs/base_recurrentvarnet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs/base_recurrentvarnet.yaml
@@ -7,28 +7,30 @@ training:
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
         -   name: FastMRI
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
                     center_fractions: [0.04]
-            crop_outer_slices: false
     batch_size: 1  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.0005
@@ -57,22 +59,27 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
             text_description: 4x  # Description for logging
         -   name: FastMRI
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]

--- a/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs/base_recurrentvarnet_ablation.yaml
+++ b/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs/base_recurrentvarnet_ablation.yaml
@@ -7,35 +7,37 @@ training:
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
         -   name: FastMRI
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
                     center_fractions: [0.04]
-            crop_outer_slices: false
     batch_size: 1  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.0005
     weight_decay: 0.0
     lr_step_size: 30000
     lr_gamma: 0.2
-    lr_warmup_iter: 100
+    lr_warmup_iter: 500
     num_iterations: 500000
     gradient_steps: 1
     gradient_clipping: 0.0
@@ -57,22 +59,27 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
             text_description: 4x  # Description for logging
         -   name: FastMRI
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]

--- a/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs/base_rim.yaml
+++ b/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs/base_rim.yaml
@@ -7,28 +7,30 @@ training:
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
         -   name: FastMRI
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
                     center_fractions: [0.04]
-            crop_outer_slices: false
     batch_size: 1  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.0002
@@ -57,9 +59,12 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
@@ -69,9 +74,12 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]

--- a/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs/base_unet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs/base_unet.yaml
@@ -7,28 +7,30 @@ training:
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
         -   name: FastMRI
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
                     center_fractions: [0.04]
-            crop_outer_slices: false
     batch_size: 1  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.002
@@ -57,22 +59,27 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
             text_description: 4x  # Description for logging
         -   name: FastMRI
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]

--- a/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs/base_varnet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs/base_varnet.yaml
@@ -7,28 +7,30 @@ training:
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
         -   name: FastMRI
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
                     center_fractions: [0.04]
-            crop_outer_slices: false
     batch_size: 1  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.0002
@@ -57,9 +59,12 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
@@ -69,9 +74,12 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]

--- a/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/4x/base_lpd.yaml
+++ b/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/4x/base_lpd.yaml
@@ -7,28 +7,30 @@ training:
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
         -   name: FastMRI
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
                     center_fractions: [0.04]
-            crop_outer_slices: false
     batch_size: 1  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.002
@@ -57,22 +59,27 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
             text_description: 4x  # Description for logging
         -   name: FastMRI
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
@@ -109,9 +116,12 @@ inference:
     dataset:
         name: FastMRI
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: FastMRIRandom
                 accelerations: [4]

--- a/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/4x/base_recurrentvarnet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/4x/base_recurrentvarnet.yaml
@@ -7,28 +7,30 @@ training:
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
         -   name: FastMRI
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
                     center_fractions: [0.04]
-            crop_outer_slices: false
     batch_size: 1  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.0005
@@ -57,22 +59,27 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
             text_description: 4x  # Description for logging
         -   name: FastMRI
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
@@ -108,9 +115,12 @@ inference:
     dataset:
         name: FastMRI
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: FastMRIRandom
                 accelerations: [4]

--- a/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/4x/base_recurrentvarnet_ablation.yaml
+++ b/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/4x/base_recurrentvarnet_ablation.yaml
@@ -7,35 +7,37 @@ training:
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
         -   name: FastMRI
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
                     center_fractions: [0.04]
-            crop_outer_slices: false
     batch_size: 1  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.0005
     weight_decay: 0.0
     lr_step_size: 30000
     lr_gamma: 0.2
-    lr_warmup_iter: 100
+    lr_warmup_iter: 500
     num_iterations: 500000
     gradient_steps: 1
     gradient_clipping: 0.0
@@ -57,22 +59,27 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
             text_description: 4x  # Description for logging
         -   name: FastMRI
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
@@ -108,9 +115,12 @@ inference:
     dataset:
         name: FastMRI
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: FastMRIRandom
                 accelerations: [4]

--- a/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/4x/base_rim.yaml
+++ b/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/4x/base_rim.yaml
@@ -7,28 +7,30 @@ training:
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
         -   name: FastMRI
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
                     center_fractions: [0.04]
-            crop_outer_slices: false
     batch_size: 1  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.0002
@@ -57,9 +59,12 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
@@ -69,9 +74,12 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
@@ -108,9 +116,12 @@ inference:
     dataset:
         name: FastMRI
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: FastMRIRandom
                 accelerations: [4]

--- a/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/4x/base_unet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/4x/base_unet.yaml
@@ -7,28 +7,30 @@ training:
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
         -   name: FastMRI
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
                     center_fractions: [0.04]
-            crop_outer_slices: false
     batch_size: 1  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.002
@@ -57,22 +59,27 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
             text_description: 4x  # Description for logging
         -   name: FastMRI
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
@@ -102,9 +109,12 @@ inference:
     dataset:
         name: FastMRI
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: FastMRIRandom
                 accelerations: [4]

--- a/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/4x/base_varnet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/4x/base_varnet.yaml
@@ -7,28 +7,30 @@ training:
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
         -   name: FastMRI
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
                     center_fractions: [0.04]
-            crop_outer_slices: false
     batch_size: 1  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.0002
@@ -57,9 +59,12 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
@@ -69,9 +74,12 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
@@ -102,9 +110,12 @@ inference:
     dataset:
         name: FastMRI
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: FastMRIRandom
                 accelerations: [4]

--- a/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/8x/base_lpd.yaml
+++ b/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/8x/base_lpd.yaml
@@ -7,28 +7,30 @@ training:
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
         -   name: FastMRI
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
                     center_fractions: [0.04]
-            crop_outer_slices: false
     batch_size: 1  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.002
@@ -57,22 +59,27 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
             text_description: 4x  # Description for logging
         -   name: FastMRI
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
@@ -109,9 +116,12 @@ inference:
     dataset:
         name: FastMRI
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: FastMRIRandom
                 accelerations: [8]

--- a/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/8x/base_recurrentvarnet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/8x/base_recurrentvarnet.yaml
@@ -7,28 +7,30 @@ training:
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
         -   name: FastMRI
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
                     center_fractions: [0.04]
-            crop_outer_slices: false
     batch_size: 1  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.0005
@@ -57,22 +59,27 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
             text_description: 4x  # Description for logging
         -   name: FastMRI
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
@@ -108,9 +115,12 @@ inference:
     dataset:
         name: FastMRI
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: FastMRIRandom
                 accelerations: [8]

--- a/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/8x/base_recurrentvarnet_ablation.yaml
+++ b/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/8x/base_recurrentvarnet_ablation.yaml
@@ -7,35 +7,37 @@ training:
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
         -   name: FastMRI
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
                     center_fractions: [0.04]
-            crop_outer_slices: false
     batch_size: 1  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.0005
     weight_decay: 0.0
     lr_step_size: 30000
     lr_gamma: 0.2
-    lr_warmup_iter: 100
+    lr_warmup_iter: 500
     num_iterations: 500000
     gradient_steps: 1
     gradient_clipping: 0.0
@@ -57,22 +59,27 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
             text_description: 4x  # Description for logging
         -   name: FastMRI
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
@@ -108,9 +115,12 @@ inference:
     dataset:
         name: FastMRI
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: FastMRIRandom
                 accelerations: [8]

--- a/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/8x/base_rim.yaml
+++ b/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/8x/base_rim.yaml
@@ -7,28 +7,30 @@ training:
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
         -   name: FastMRI
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
                     center_fractions: [0.04]
-            crop_outer_slices: false
     batch_size: 1  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.0002
@@ -57,9 +59,12 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
@@ -69,9 +74,12 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
@@ -108,9 +116,12 @@ inference:
     dataset:
         name: FastMRI
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: FastMRIRandom
                 accelerations: [8]

--- a/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/8x/base_unet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/8x/base_unet.yaml
@@ -7,28 +7,30 @@ training:
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
         -   name: FastMRI
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
                     center_fractions: [0.04]
-            crop_outer_slices: false
     batch_size: 1  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.002
@@ -57,22 +59,27 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
             text_description: 4x  # Description for logging
         -   name: FastMRI
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
@@ -102,9 +109,12 @@ inference:
     dataset:
         name: FastMRI
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: FastMRIRandom
                 accelerations: [8]

--- a/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/8x/base_varnet.yaml
+++ b/projects/cvpr2022_recurrentvarnet/fastmri/AXT1_brain/configs_inference/8x/base_varnet.yaml
@@ -7,28 +7,30 @@ training:
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
                     center_fractions: [0.08]
-            crop_outer_slices: false
         -   name: FastMRI
             filenames_lists:
                 - ../lists/train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
                     center_fractions: [0.04]
-            crop_outer_slices: false
     batch_size: 1  # This is the batch size per GPU!
     optimizer: Adam
     lr: 0.0002
@@ -57,9 +59,12 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [4]
@@ -69,9 +74,12 @@ validation:
             filenames_lists:
                 - ../lists/val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [8]
@@ -102,9 +110,12 @@ inference:
     dataset:
         name: FastMRI
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: FastMRIRandom
                 accelerations: [8]

--- a/projects/spie2022_radial_subsampling/configs/base_radial.yaml
+++ b/projects/spie2022_radial_subsampling/configs/base_radial.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: Radial
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: Radial
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../lists/val/12x218x170_val.lst
                 - ../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: Radial
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../lists/val/12x218x170_val.lst
                 - ../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: Radial
                     accelerations: [10]
@@ -105,13 +115,3 @@ additional_models:
 logging:
     tensorboard:
         num_images: 4
-inference:
-    batch_size: 8
-    dataset:
-        name: CalgaryCampinas
-        crop_outer_slices: true
-        text_description: inference
-        transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace

--- a/projects/spie2022_radial_subsampling/configs/base_rectilinear.yaml
+++ b/projects/spie2022_radial_subsampling/configs/base_rectilinear.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [5, 10]
@@ -21,10 +23,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [5, 10]
@@ -59,9 +63,12 @@ validation:
                 - ../lists/val/12x218x170_val.lst
                 - ../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [5]
@@ -73,9 +80,12 @@ validation:
                 - ../lists/val/12x218x170_val.lst
                 - ../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [10]
@@ -109,13 +119,3 @@ additional_models:
 logging:
     tensorboard:
         num_images: 4
-inference:
-    batch_size: 8
-    dataset:
-        name: CalgaryCampinas
-        crop_outer_slices: true
-        text_description: inference
-        transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace

--- a/projects/spie2022_radial_subsampling/configs/inference/10x/base_radial.yaml
+++ b/projects/spie2022_radial_subsampling/configs/inference/10x/base_radial.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: Radial
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: Radial
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../lists/val/12x218x170_val.lst
                 - ../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: Radial
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../lists/val/12x218x170_val.lst
                 - ../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: Radial
                     accelerations: [10]
@@ -110,9 +120,12 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: Radial
                 accelerations: [10]

--- a/projects/spie2022_radial_subsampling/configs/inference/10x/base_rectilinear.yaml
+++ b/projects/spie2022_radial_subsampling/configs/inference/10x/base_rectilinear.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [5, 10]
@@ -21,10 +23,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [5, 10]
@@ -59,9 +63,12 @@ validation:
                 - ../lists/val/12x218x170_val.lst
                 - ../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [5]
@@ -73,9 +80,12 @@ validation:
                 - ../lists/val/12x218x170_val.lst
                 - ../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [10]
@@ -114,12 +124,15 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: FastMRIRandom
-                    accelerations: [10]
-                    center_fractions: [0.05]
+                accelerations: [10]
+                center_fractions: [0.05]
         crop_outer_slices: true
         text_description: inference-10x

--- a/projects/spie2022_radial_subsampling/configs/inference/5x/base_radial.yaml
+++ b/projects/spie2022_radial_subsampling/configs/inference/5x/base_radial.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: Radial
                     accelerations: [5, 10]
@@ -20,10 +22,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: Radial
                     accelerations: [5, 10]
@@ -57,9 +61,12 @@ validation:
                 - ../lists/val/12x218x170_val.lst
                 - ../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: Radial
                     accelerations: [5]
@@ -70,9 +77,12 @@ validation:
                 - ../lists/val/12x218x170_val.lst
                 - ../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: Radial
                     accelerations: [10]
@@ -110,9 +120,12 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: Radial
                 accelerations: [5]

--- a/projects/spie2022_radial_subsampling/configs/inference/5x/base_rectilinear.yaml
+++ b/projects/spie2022_radial_subsampling/configs/inference/5x/base_rectilinear.yaml
@@ -8,10 +8,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x170_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [5, 10]
@@ -21,10 +23,12 @@ training:
             filenames_lists:
                 - ../lists/train/12x218x180_train.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [5, 10]
@@ -59,9 +63,12 @@ validation:
                 - ../lists/val/12x218x170_val.lst
                 - ../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [5]
@@ -73,9 +80,12 @@ validation:
                 - ../lists/val/12x218x170_val.lst
                 - ../lists/val/12x218x180_val.lst
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [10]
@@ -114,12 +124,15 @@ inference:
     dataset:
         name: CalgaryCampinas
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: FastMRIRandom
-                    accelerations: [5]
-                    center_fractions: [0.1]
+                accelerations: [5]
+                center_fractions: [0.1]
         crop_outer_slices: true
         text_description: inference-5x

--- a/projects/toy/base.yaml
+++ b/projects/toy/base.yaml
@@ -8,10 +8,12 @@ training:
             num_coils: 8
             spatial_shape: [11, 32, 40]
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
                 masking:
                     name: FastMRIRandom
                     accelerations: [5]
@@ -46,9 +48,12 @@ validation:
             num_coils: 8
             spatial_shape: [11, 32, 40]
             transforms:
-                crop: null
-                estimate_sensitivity_maps: true
-                scaling_key: masked_kspace
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [5]
@@ -78,6 +83,9 @@ inference:
         name:  FakeMRIBlobs
         text_description: inference
         transforms:
-            crop: null
-            estimate_sensitivity_maps: true
-            scaling_key: masked_kspace
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace

--- a/projects/toy/shepp_logan/base_unet.yaml
+++ b/projects/toy/shepp_logan/base_unet.yaml
@@ -5,9 +5,12 @@ training:
     datasets:
         -   name: SheppLoganProton
             transforms:
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [ 5, 10 ]
@@ -17,9 +20,12 @@ training:
             text_description: shepp-logan-proton
         -   name: SheppLoganT1
             transforms:
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [ 5, 10 ]
@@ -53,9 +59,12 @@ validation:
         # Twice the same dataset but a different acceleration factor
         -   name:  SheppLoganT2
             transforms:
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [ 5 ]
@@ -65,9 +74,12 @@ validation:
             text_description: shepp-logan-T2-val5x
         -   name: SheppLoganT2
             transforms:
-                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-                scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-                image_center_crop: false
+                cropping:
+                    crop: null
+                sensitivity_map_estimation:
+                    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+                normalization:
+                    scaling_key: masked_kspace
                 masking:
                     name: FastMRIRandom
                     accelerations: [ 10 ]
@@ -99,9 +111,12 @@ inference:
     dataset:
         name: SheppLoganT1
         transforms:
-            estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
-            scaling_key: masked_kspace  # Compute the image normalization based on the masked_kspace maximum
-            image_center_crop: false
+            cropping:
+                crop: null
+            sensitivity_map_estimation:
+                estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
+            normalization:
+                scaling_key: masked_kspace
             masking:
                 name: FastMRIRandom
                 accelerations: [ 5 ]

--- a/tests/tests_data/test_mri_transforms.py
+++ b/tests/tests_data/test_mri_transforms.py
@@ -34,6 +34,7 @@ from direct.data.mri_transforms import (
 )
 from direct.data.transforms import fft2, ifft2, modulus
 from direct.exceptions import ItemNotFoundException
+from direct.types import IntegerListOrTupleString
 
 
 def create_sample(shape, **kwargs):
@@ -176,7 +177,7 @@ def test_ApplyMask(shape):
 )
 @pytest.mark.parametrize(
     "crop",
-    [(5, 6), "reconstruction_size", None, "invalid_key"],
+    [(5, 6), "reconstruction_size", "[5, 6]", "(5, 6)", None, "invalid_key"],
 )
 @pytest.mark.parametrize(
     "image_space_center_crop",
@@ -227,6 +228,8 @@ def test_CropKspace(
         if crop == "reconstruction_size":
             crop_shape = tuple((d // 2 for d in shape[1:]))
             sample.update({"reconstruction_size": crop_shape})
+        elif isinstance(crop, IntegerListOrTupleString):
+            crop_shape = tuple(IntegerListOrTupleString(crop))
 
         transform = CropKspace(**args)
 


### PR DESCRIPTION
…46, #247, #249)

Minor code fixes:
* Fix transforms creation for inference using `dict_flatten`

Config fixes:
* Update projects/<configs>  to new transforms config:
``` 
cropping:
    crop: null
sensitivity_map_estimation:
    estimate_sensitivity_maps: true  # Estimate the sensitivity map on the ACS
normalization:
    scaling_key: masked_kspace
```

Documentation fixes:
* Update some documentation files